### PR TITLE
Update htaccess to grant access on Apache 2.4

### DIFF
--- a/assets/.htaccess
+++ b/assets/.htaccess
@@ -1,2 +1,7 @@
-order allow,deny
-allow from all
+<IfModule !mod_authz_core.c>
+  Order allow,deny
+  Allow from all
+</IfModule>
+<IfModule mod_authz_core.c>
+  Require all granted
+</IfModule>


### PR DESCRIPTION
Die Erweiterung funktioniert unter Apache 2.4 nicht mehr (z.b. xampp ist davon betroffen). More informations contao/core#5032
