### PR TITLE
Fix the inner element check in colset end element.

### DIFF
--- a/elements/colsetEnd.php
+++ b/elements/colsetEnd.php
@@ -105,7 +105,7 @@ class colsetEnd extends \ContentElement
         $useGap = $GLOBALS['TL_SUBCL'][$this->strSet]['gap'];
         $blnUseInner = $GLOBALS['TL_SUBCL'][$this->strSet]['inside'];
 
-        if($this->sc_gapdefault != 1 && !$useGap)
+        if($this->sc_gapdefault != 1 || !$useGap)
         {
             $blnUseInner = false;
         }


### PR DESCRIPTION
The inversion of `$this->sc_gapdefault == 1 && $useGap` is `$this->sc_gapdefault != 1 || !$useGap`.
