### PR TITLE
Update tl_content.php

### DIFF
--- a/dca/tl_content.php
+++ b/dca/tl_content.php
@@ -615,8 +615,14 @@ class tl_content_sc extends tl_content
 	/* Toggle-Status auf Trenn und End-elemente anwenden */
 	public function toggleAdditionalElements($varValue,$dc)
 	{
-		$objEntry = $this->Database->prepare("UPDATE tl_content SET tstamp=". time() .", invisible='" . ( $varValue ? 1 : '') . "' WHERE sc_parent=? AND type!=?")->execute($dc->id,'colsetStart');
-		
+
+		if($dc->id != 0)
+		{
+			$objEntry = $this->Database->prepare("UPDATE tl_content SET tstamp=". time() .", invisible='" . ( $varValue ? 1 : '') . "' WHERE sc_parent=? AND type!=?")->execute($dc->id,'colsetStart');
+
+			return $varValue;
+		}
+
 		return $varValue;
 	
 	}


### PR DESCRIPTION
Die Funktion "Mehrere bearbeiten" -> "Unsichtbar" schaltet sämtliche (auch nicht gewählte) Inhaltselemente an/aus. 
Das liegt daran, dass $dc->id am Anfang des Durchlaufs 0 ist und somit die Abfrage in "UPDATE tl_content SET ... invisible='1' WHERE sc_parent ='0' AND type!='colsetStart'" resultiert. Alle Elemente, die nicht vom Typ Subcolumns sind, haben den Wert sc_parent=0

Warum $dc->id anfangs 0 ist, hab ich nicht geblickt. Aber das ist auf jedenfall ein Workaround, vielleicht weißt du was besseres.

Grüße :)
