### PR TITLE
Change the required version for multicolumnwizard.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"php":">=5.3",
 		"contao/core":">=3,<4",
 		"contao-community-alliance/composer-plugin":"~2.0",
-		"menatwork/contao-multicolumnwizard":"3.2.*"
+		"menatwork/contao-multicolumnwizard":"~3.2"
 	},
 	"autoload":{
 		"classmap":[""]


### PR DESCRIPTION
We have a new version from mcw. We need this for the new MetaModels core. so we have to change the required version from mcv from 3.2.\* to ~3.2. 
