### PR TITLE
Fixed: Kopieren von Seiten

### DIFF
--- a/tl_subcolumnsCallback.php
+++ b/tl_subcolumnsCallback.php
@@ -139,7 +139,7 @@ class tl_subcolumnsCallback extends Backend
 											    ->limit(1)
 												->execute($oldChilds[0]);
 				
-				$newChilds = $this->Database->prepare("SELECT id,type FROM tl_content WHERE pid=? AND sc_parent=? AND type != 'colsetStart'")
+				$newChilds = $this->Database->prepare("SELECT id,type FROM tl_content WHERE pid=? AND sc_parent=? AND type != 'colsetStart' ORDER BY sorting")
 												->execute($pid,$oldChildParent->sc_parent);
 				$i=1;
 				while($newChilds->next())


### PR DESCRIPTION
https://github.com/felixpfeiffer/Contao-Subcolumns/issues/8

Sollte es beseitigen.

Wenn die Einträge aus der Datenbank geholten werden aber die Reihenfolge der ID nicht mit sorting stimmt, verschluckt sich das Script sonst.